### PR TITLE
feat: Add comprehensive backend tests

### DIFF
--- a/backend/app/tests/api/v1/endpoints/test_feeds.py
+++ b/backend/app/tests/api/v1/endpoints/test_feeds.py
@@ -1,0 +1,366 @@
+# backend/app/tests/api/v1/endpoints/test_feeds.py
+import uuid
+from unittest.mock import patch, MagicMock
+
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+# Models
+from app.db.models import Folder as FolderModel
+from app.db.models import Feed as FeedModel
+from app.db.models import Article as ArticleModel
+
+# Schemas for mocking service layer
+from app.services.feed_parser import FeedData, ArticleData
+
+
+# Mock data structures remain local as they are specific to feed parsing scenarios
+MOCK_ARTICLE_1 = ArticleData(
+    title="Mock Article 1",
+    link="http://example.com/article1",
+    published_at="2023-01-01T12:00:00Z", # Ensure this is ISO format parsable by datetime
+    guid="guid1"
+)
+MOCK_ARTICLE_2 = ArticleData(
+    title="Mock Article 2",
+    link="http://example.com/article2",
+    published_at="2023-01-02T12:00:00Z",
+    guid="guid2"
+)
+MOCK_NEW_ARTICLE_AFTER_REFRESH = ArticleData(
+    title="Mock New Article",
+    link="http://example.com/new_article",
+    published_at="2023-01-03T12:00:00Z",
+    guid="guid_new"
+)
+
+MOCK_FEED_DATA = FeedData(
+    title="Mock Feed Title",
+    link="http://example.com/feed",
+    site_url="http://example.com",
+    description="Mock feed description",
+    articles=[MOCK_ARTICLE_1, MOCK_ARTICLE_2]
+)
+
+MOCK_FEED_DATA_REFRESHED = FeedData(
+    title="Mock Feed Title", # Title might be the same or updated
+    link="http://example.com/feed",
+    site_url="http://example.com",
+    description="Mock feed description updated",
+    articles=[MOCK_ARTICLE_1, MOCK_ARTICLE_2, MOCK_NEW_ARTICLE_AFTER_REFRESH] # Includes new article
+)
+
+
+class TestFeedEndpoints:
+
+    # Helper to add a feed via API for reuse
+    # Helper to add a feed via API for reuse - stays as a local method
+    def _add_feed_via_api(self, client: TestClient, feed_url: str, folder_id: uuid.UUID = None): # Return type hint can be added e.g. -> Response
+        payload = {"url": feed_url}
+        if folder_id:
+            payload["folder_id"] = str(folder_id) # Ensure UUID is stringified for JSON
+        return client.post("/api/v1/feeds/", json=payload)
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_add_new_feed_no_folder(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        feed_url = "http://example.com/feed"
+
+        response = self._add_feed_via_api(client, feed_url)
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == MOCK_FEED_DATA.title
+        assert data["feed_url"] == feed_url # Original URL used for adding
+        assert data["site_url"] == MOCK_FEED_DATA.site_url
+        assert data["folder_id"] is None
+        assert len(data["articles"]) == len(MOCK_FEED_DATA.articles)
+        # Check one article for structure
+        if data["articles"]:
+            assert data["articles"][0]["title"] == MOCK_ARTICLE_1.title
+
+        # Verify in DB
+        feed_id = data["id"]
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == feed_id).first()
+        assert db_feed is not None
+        assert db_feed.title == MOCK_FEED_DATA.title
+        assert len(db_feed.articles) == len(MOCK_FEED_DATA.articles)
+        mock_parse_feed.assert_called_once_with(feed_url)
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_add_new_feed_with_folder(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session, folder_factory):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        folder = folder_factory(name="Test Folder for Feeds") # Use folder_factory
+        feed_url = "http://another.example.com/feed"
+
+        response = self._add_feed_via_api(client, feed_url, folder_id=folder.id)
+
+        assert response.status_code == 201
+        data = response.json()
+        assert data["title"] == MOCK_FEED_DATA.title
+        assert data["folder_id"] == str(folder.id)
+        
+        # Verify in DB
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == data["id"]).first()
+        assert db_feed is not None
+        assert db_feed.folder_id == folder.id
+        mock_parse_feed.assert_called_once_with(feed_url)
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_add_feed_invalid_url_parse_error(self, mock_parse_feed: MagicMock, client: TestClient):
+        feed_url = "http://invalid-url.com/feed"
+        mock_parse_feed.side_effect = ValueError("Failed to parse feed") # Simulate parsing failure
+
+        response = self._add_feed_via_api(client, feed_url)
+        
+        assert response.status_code == 400 # Or 422 depending on actual error handling
+        # Example: {"detail": "Error parsing feed: Failed to parse feed"}
+        assert "detail" in response.json() 
+        # Check if the detail contains the exception message might be too brittle.
+        # Check for a specific error key if the API provides one.
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_add_duplicate_feed_url(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        feed_url = "http://duplicate.example.com/feed"
+
+        # Add first feed
+        response1 = self._add_feed_via_api(client, feed_url)
+        assert response1.status_code == 201
+
+        # Attempt to add second feed with same URL
+        # The mock_parse_feed might be called again or not, depending on how early the duplicate check is.
+        # If it's checked before parsing, mock_parse_feed might be called only once.
+        # If it's checked after parsing (e.g. unique constraint in DB on feed_url), then it would be called again.
+        # Let's assume the DB handles the unique constraint for feed_url.
+        mock_parse_feed.reset_mock() # Reset mock for the second call
+        mock_parse_feed.return_value = MOCK_FEED_DATA 
+
+        response2 = self._add_feed_via_api(client, feed_url)
+        assert response2.status_code == 400 # Expecting Bad Request for duplicate
+        assert "detail" in response2.json()
+        # E.g. "Feed with this URL already exists"
+
+    def test_list_feeds_empty(self, client: TestClient):
+        response = client.get("/api/v1/feeds/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_list_feeds_with_content(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session, folder_factory):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        
+        folder = folder_factory(name="FeedList Folder") # Use folder_factory
+        
+        # Add feed 1 (no folder)
+        # _add_feed_via_api returns a Response object, call .json() when asserting content
+        resp1 = self._add_feed_via_api(client, "http://feed1.com/rss")
+        assert resp1.status_code == 201
+        id1 = resp1.json()["id"]
+
+        # Add feed 2 (with folder)
+        resp2 = self._add_feed_via_api(client, "http://feed2.com/rss", folder_id=folder.id)
+        assert resp2.status_code == 201
+        id2 = resp2.json()["id"]
+
+        response = client.get("/api/v1/feeds/")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        
+        feed_details = {f["id"]: f for f in data}
+        assert id1 in feed_details
+        assert feed_details[id1]["title"] == MOCK_FEED_DATA.title
+        assert feed_details[id1]["folder_id"] is None
+        
+        assert id2 in feed_details
+        assert feed_details[id2]["title"] == MOCK_FEED_DATA.title
+        assert feed_details[id2]["folder_id"] == str(folder.id)
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_delete_feed_success(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        feed_url = "http://tobedeleted.com/feed"
+        
+        add_response = self._add_feed_via_api(client, feed_url)
+        assert add_response.status_code == 201
+        feed_id = add_response.json()["id"]
+        
+        # Verify articles were added
+        article_count = db_session.query(ArticleModel).filter(ArticleModel.feed_id == feed_id).count()
+        assert article_count == len(MOCK_FEED_DATA.articles)
+
+        delete_response = client.delete(f"/api/v1/feeds/{feed_id}")
+        assert delete_response.status_code == 200
+        assert delete_response.json() == {"message": "Feed deleted successfully"} # Or {"ok": True}
+
+        # Verify feed and articles deleted from DB
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == feed_id).first()
+        assert db_feed is None
+        article_count_after_delete = db_session.query(ArticleModel).filter(ArticleModel.feed_id == feed_id).count()
+        assert article_count_after_delete == 0
+    
+    def test_delete_feed_non_existent(self, client: TestClient):
+        non_existent_id = uuid.uuid4()
+        response = client.delete(f"/api/v1/feeds/{non_existent_id}")
+        assert response.status_code == 404
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_list_articles_for_feed(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        feed_url = "http://feedwitharticles.com/rss"
+        
+        add_response = self._add_feed_via_api(client, feed_url)
+        assert add_response.status_code == 201
+        feed_id = add_response.json()["id"]
+
+        response = client.get(f"/api/v1/feeds/{feed_id}/articles/")
+        assert response.status_code == 200
+        articles_data = response.json()
+        assert len(articles_data) == len(MOCK_FEED_DATA.articles)
+        # Verify some content if needed, e.g., titles
+        response_titles = {a["title"] for a in articles_data}
+        mock_titles = {a.title for a in MOCK_FEED_DATA.articles}
+        assert response_titles == mock_titles
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_list_articles_for_feed_no_articles(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        empty_feed_data = FeedData(title="Empty Feed", link="http://empty.com", site_url="http://empty.com", description="", articles=[])
+        mock_parse_feed.return_value = empty_feed_data
+        feed_url = "http://emptyfeed.com/rss"
+        
+        add_response = self._add_feed_via_api(client, feed_url)
+        assert add_response.status_code == 201
+        feed_id = add_response.json()["id"]
+
+        response = client.get(f"/api/v1/feeds/{feed_id}/articles/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_articles_for_non_existent_feed(self, client: TestClient):
+        non_existent_id = uuid.uuid4()
+        response = client.get(f"/api/v1/feeds/{non_existent_id}/articles/")
+        assert response.status_code == 404
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_refresh_feed(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session):
+        # Initial add
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        feed_url = "http://refreshme.com/feed"
+        add_response = self._add_feed_via_api(client, feed_url)
+        assert add_response.status_code == 201
+        feed_id = add_response.json()["id"]
+        initial_article_count = len(MOCK_FEED_DATA.articles)
+        assert len(add_response.json()["articles"]) == initial_article_count
+
+        # Configure mock for refresh to return new data
+        mock_parse_feed.reset_mock()
+        mock_parse_feed.return_value = MOCK_FEED_DATA_REFRESHED
+        
+        refresh_response = client.post(f"/api/v1/feeds/{feed_id}/refresh")
+        assert refresh_response.status_code == 200
+        data = refresh_response.json()
+        
+        # Response should be the updated feed with all articles (old + new)
+        assert data["id"] == str(feed_id)
+        assert len(data["articles"]) == len(MOCK_FEED_DATA_REFRESHED.articles)
+        
+        # Verify in DB
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == feed_id).first()
+        assert db_feed is not None
+        assert len(db_feed.articles) == len(MOCK_FEED_DATA_REFRESHED.articles)
+        
+        # Check that the new article is present
+        new_article_titles = {a.title for a in db_feed.articles}
+        assert MOCK_NEW_ARTICLE_AFTER_REFRESH.title in new_article_titles
+        mock_parse_feed.assert_called_once_with(feed_url) # feed_url should be stored in db_feed.feed_url
+
+    def test_refresh_non_existent_feed(self, client: TestClient):
+        non_existent_id = uuid.uuid4()
+        response = client.post(f"/api/v1/feeds/{non_existent_id}/refresh")
+        assert response.status_code == 404
+
+    @patch('app.services.feed_parser.fetch_feed_title_and_url')
+    def test_fetch_feed_title_success(self, mock_fetch: MagicMock, client: TestClient):
+        mocked_title = "Fetched Title"
+        mocked_resolved_url = "http://resolved.example.com/feed"
+        mock_fetch.return_value = (mocked_title, mocked_resolved_url)
+        
+        test_url = "http://testurl.com/maybe-redirects"
+        response = client.post("/api/v1/feeds/fetchFeedTitle", json={"url": test_url})
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["title"] == mocked_title
+        assert data["url"] == mocked_resolved_url
+        mock_fetch.assert_called_once_with(test_url)
+
+    @patch('app.services.feed_parser.fetch_feed_title_and_url')
+    def test_fetch_feed_title_failure(self, mock_fetch: MagicMock, client: TestClient):
+        mock_fetch.side_effect = ValueError("Could not fetch title")
+        
+        test_url = "http://nonexistenturl.com"
+        response = client.post("/api/v1/feeds/fetchFeedTitle", json={"url": test_url})
+        
+        assert response.status_code == 400 # Or 422
+        assert "detail" in response.json()
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_move_feed_to_folder(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session, folder_factory):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        # Create feed without folder
+        feed_resp = self._add_feed_via_api(client, "http://movablefeed.com/rss")
+        assert feed_resp.status_code == 201
+        feed_id = feed_resp.json()["id"]
+        assert feed_resp.json()["folder_id"] is None
+
+        # Create folder
+        folder = folder_factory(name="Target Folder") # Use folder_factory
+
+        # Move feed
+        move_response = client.patch(f"/api/v1/feeds/{feed_id}/move", json={"folder_id": str(folder.id)})
+        assert move_response.status_code == 200
+        data = move_response.json()
+        assert data["id"] == str(feed_id)
+        assert data["folder_id"] == str(folder.id)
+
+        # Verify in DB
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == feed_id).first()
+        assert db_feed.folder_id == folder.id
+
+    @patch('app.services.feed_parser.parse_feed')
+    def test_move_feed_to_null_folder(self, mock_parse_feed: MagicMock, client: TestClient, db_session: Session, folder_factory):
+        mock_parse_feed.return_value = MOCK_FEED_DATA
+        folder = folder_factory(name="Initial Folder") # Use folder_factory
+        
+        # Create feed with folder
+        feed_resp = self._add_feed_via_api(client, "http://removablefromfolder.com/rss", folder_id=folder.id)
+        assert feed_resp.status_code == 201
+        feed_id = feed_resp.json()["id"]
+        assert feed_resp.json()["folder_id"] == str(folder.id)
+
+        # Move feed to null (remove from folder)
+        move_response = client.patch(f"/api/v1/feeds/{feed_id}/move", json={"folder_id": None})
+        assert move_response.status_code == 200
+        data = move_response.json()
+        assert data["id"] == str(feed_id)
+        assert data["folder_id"] is None
+
+        # Verify in DB
+        db_feed = db_session.query(FeedModel).filter(FeedModel.id == feed_id).first()
+        assert db_feed.folder_id is None
+
+    def test_move_feed_to_non_existent_folder(self, client: TestClient, db_session: Session, feed_factory): # Added feed_factory
+        # Create a feed to attempt to move
+        feed_to_move = feed_factory() # Use feed_factory
+        
+        non_existent_folder_id = uuid.uuid4()
+        response = client.patch(f"/api/v1/feeds/{feed_to_move.id}/move", json={"folder_id": str(non_existent_folder_id)})
+        assert response.status_code == 404 # Folder not found
+
+    def test_move_non_existent_feed(self, client: TestClient, db_session: Session, folder_factory): # Added folder_factory
+        folder = folder_factory(name="Some Folder") # Use folder_factory
+        non_existent_feed_id = uuid.uuid4()
+        
+        response = client.patch(f"/api/v1/feeds/{non_existent_feed_id}/move", json={"folder_id": str(folder.id)})
+        assert response.status_code == 404 # Feed not found

--- a/backend/app/tests/api/v1/endpoints/test_folders.py
+++ b/backend/app/tests/api/v1/endpoints/test_folders.py
@@ -1,0 +1,171 @@
+# backend/app/tests/api/v1/endpoints/test_folders.py
+from fastapi.testclient import TestClient
+from sqlalchemy.orm import Session
+
+from app.db.models import Folder as FolderModel # Alias to avoid name clash
+from app.schemas.folder import FolderCreate, FolderUpdate # FolderCreate/Update not directly used in these tests but good for context
+
+
+# Helper function to create folder via API for reuse in tests
+# This remains as it's specific to API testing with TestClient
+def _create_folder_via_api(client: TestClient, name: str) -> dict: # Renamed for clarity (internal helper)
+    response = client.post("/api/v1/folders/", json={"name": name})
+    return response
+
+class TestFolderEndpoints:
+
+    def test_create_folder_success(self, client: TestClient, db_session: Session):
+        folder_name = "Test Folder Create"
+        response = _create_folder_via_api(client, folder_name)
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert data["name"] == folder_name
+        assert "id" in data
+        assert data["feeds"] == [] # As per requirements
+
+        # Verify in DB
+        folder_id = data["id"]
+        db_folder = db_session.query(FolderModel).filter(FolderModel.id == folder_id).first()
+        assert db_folder is not None
+        assert db_folder.name == folder_name
+
+    def test_create_folder_duplicate_name(self, client: TestClient, db_session: Session): # db_session might not be strictly needed if not verifying DB directly after API call
+        folder_name = "Unique Folder Name"
+        # Create first folder
+        response1 = _create_folder_via_api(client, folder_name)
+        assert response1.status_code == 201
+
+        # Attempt to create second folder with the same name
+        response2 = _create_folder_via_api(client, folder_name)
+        assert response2.status_code == 400
+        data = response2.json()
+        assert "detail" in data
+        # Check specific error message if consistent
+        # assert data["detail"] == "Folder with this name already exists"
+
+    def test_create_folder_invalid_data(self, client: TestClient):
+        # Test with empty name
+        response_empty_name = _create_folder_via_api(client, "")
+        assert response_empty_name.status_code == 422
+
+        # Test with name exceeding max length (Folder model: String(100))
+        long_name = "a" * 101 
+        response_long_name = _create_folder_via_api(client, long_name)
+        assert response_long_name.status_code == 422
+
+    def test_list_folders_empty(self, client: TestClient):
+        response = client.get("/api/v1/folders/")
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_list_folders_with_content(self, client: TestClient, db_session: Session): # db_session not strictly needed here if relying on API state
+        folder_name1 = "Folder Alpha"
+        folder_name2 = "Folder Beta"
+        
+        resp1 = _create_folder_via_api(client, folder_name1)
+        assert resp1.status_code == 201
+        id1 = resp1.json()["id"]
+
+        resp2 = _create_folder_via_api(client, folder_name2)
+        assert resp2.status_code == 201
+        id2 = resp2.json()["id"]
+
+        response = client.get("/api/v1/folders/")
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 2
+        
+        # Verify structure and content (order might not be guaranteed)
+        folder_names_in_response = {f["name"] for f in data}
+        folder_ids_in_response = {f["id"] for f in data}
+
+        assert folder_name1 in folder_names_in_response
+        assert folder_name2 in folder_names_in_response
+        assert id1 in folder_ids_in_response
+        assert id2 in folder_ids_in_response
+        for item in data:
+            assert item["feeds"] == []
+
+    def test_rename_folder_success(self, client: TestClient, db_session: Session):
+        original_name = "Old Name"
+        new_name = "New Name"
+
+        create_response = _create_folder_via_api(client, original_name)
+        assert create_response.status_code == 201
+        folder_id = create_response.json()["id"]
+
+        rename_response = client.put(f"/api/v1/folders/{folder_id}", json={"name": new_name})
+        assert rename_response.status_code == 200
+        data = rename_response.json()
+        assert data["id"] == folder_id
+        assert data["name"] == new_name
+        assert data["feeds"] == []
+
+        # Verify in DB
+        db_folder = db_session.query(FolderModel).filter(FolderModel.id == folder_id).first()
+        assert db_folder is not None
+        assert db_folder.name == new_name
+
+    def test_rename_folder_non_existent(self, client: TestClient):
+        non_existent_id = 99999
+        response = client.put(f"/api/v1/folders/{non_existent_id}", json={"name": "Doesnt Matter"})
+        assert response.status_code == 404
+
+    def test_rename_folder_to_duplicate_name(self, client: TestClient, folder_factory): # Use folder_factory if direct DB setup is preferred
+        name1 = "Existing Name 1"
+        name2 = "Existing Name 2"
+
+        # Create via API to test API-level duplicate check during rename
+        folder1_resp = _create_folder_via_api(client, name1)
+        assert folder1_resp.status_code == 201
+        folder1_id = folder1_resp.json()["id"]
+        
+        _ = _create_folder_via_api(client, name2) # Create the second folder that name1 will conflict with
+        assert _.status_code == 201
+
+
+        # Try to rename folder1 to folder2's name
+        response = client.put(f"/api/v1/folders/{folder1_id}", json={"name": name2})
+        assert response.status_code == 400
+
+    def test_rename_folder_invalid_data(self, client: TestClient, db_session: Session): # db_session for potential direct verification if needed
+        folder_name = "Valid Original Name"
+        create_response = _create_folder_via_api(client, folder_name)
+        assert create_response.status_code == 201
+        folder_id = create_response.json()["id"]
+
+        # Test with empty name
+        response_empty_name = client.put(f"/api/v1/folders/{folder_id}", json={"name": ""})
+        assert response_empty_name.status_code == 422
+
+        # Test with name too long (Folder model: String(100))
+        long_name = "b" * 101
+        response_long_name = client.put(f"/api/v1/folders/{folder_id}", json={"name": long_name})
+        assert response_long_name.status_code == 422
+
+    def test_delete_folder_success(self, client: TestClient, db_session: Session):
+        folder_name = "To Be Deleted"
+        create_response = _create_folder_via_api(client, folder_name)
+        assert create_response.status_code == 201
+        folder_id = create_response.json()["id"]
+
+        delete_response = client.delete(f"/api/v1/folders/{folder_id}")
+        assert delete_response.status_code == 200
+        data = delete_response.json()
+        assert data["message"] == "Folder deleted successfully"
+
+        # Verify in DB
+        db_folder = db_session.query(FolderModel).filter(FolderModel.id == folder_id).first()
+        assert db_folder is None
+
+    def test_delete_folder_non_existent(self, client: TestClient):
+        non_existent_id = 88888 # Consider using uuid.uuid4() for non_existent_ids
+        response = client.delete(f"/api/v1/folders/{non_existent_id}")
+        assert response.status_code == 404
+
+    # Test for deleting folder with feeds would require feed creation logic first.
+    # This is more of an integration test between folder and feed services/models.
+    # def test_delete_folder_with_feeds(self, client: TestClient, db_session: Session, feed_factory):
+    # pass
+

--- a/backend/app/tests/api/v1/endpoints/test_status.py
+++ b/backend/app/tests/api/v1/endpoints/test_status.py
@@ -1,0 +1,89 @@
+# backend/app/tests/api/v1/endpoints/test_status.py
+import re
+from datetime import datetime
+from fastapi.testclient import TestClient
+
+# Assuming APP_VERSION is accessible via app.main or a config module
+# If app.main.APP_VERSION is not the correct way, this will need adjustment
+from app.main import APP_VERSION
+
+def assert_iso_timestamp(timestamp_str: str):
+    """Helper to assert that a string is a valid ISO 8601 timestamp."""
+    try:
+        datetime.fromisoformat(timestamp_str.replace("Z", "+00:00"))
+        return True
+    except (ValueError, TypeError):
+        return False
+
+def test_get_simple_status(client: TestClient):
+    """Test GET /api/v1/status/simple endpoint."""
+    response = client.get("/api/v1/status/simple")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["status"] == "ok" # Changed from "OK" to "ok" to match example in STATUS_ENDPOINTS.md
+    assert "timestamp" in data
+    assert assert_iso_timestamp(data["timestamp"])
+    assert data["database"] == "connected"
+
+def test_get_full_status(client: TestClient):
+    """Test GET /api/v1/status/ endpoint."""
+    response = client.get("/api/v1/status/")
+    assert response.status_code == 200
+    data = response.json()
+
+    # Check top-level keys
+    expected_top_level_keys = ["status", "timestamp", "uptime_seconds", "version", "database", "system"]
+    for key in expected_top_level_keys:
+        assert key in data
+
+    # Validate specific fields
+    assert data["status"] == "ok"
+    assert assert_iso_timestamp(data["timestamp"])
+    assert isinstance(data["uptime_seconds"], (int, float)) and data["uptime_seconds"] >= 0
+    assert data["version"] == APP_VERSION
+
+    # Validate "database" sub-keys
+    assert data["database"]["connected"] is True
+    assert isinstance(data["database"]["message"], str)
+    assert isinstance(data["database"]["response_time_ms"], (int, float)) and data["database"]["response_time_ms"] >= 0
+
+    # Validate "system" sub-keys (presence and type)
+    expected_system_keys = [
+        "python_version", "platform", "architecture", "cpu_cores", 
+        "total_memory_gb", "available_memory_gb", "load_average_1m", 
+        "load_average_5m", "load_average_15m"
+    ]
+    for key in expected_system_keys:
+        assert key in data["system"]
+    
+    assert isinstance(data["system"]["python_version"], str)
+    assert isinstance(data["system"]["platform"], str)
+    # cpu_cores can be None if detection fails, so allow None or int
+    assert data["system"]["cpu_cores"] is None or isinstance(data["system"]["cpu_cores"], int)
+    assert isinstance(data["system"]["total_memory_gb"], (int, float))
+    assert isinstance(data["system"]["available_memory_gb"], (int, float))
+    # load averages can be None if not available (e.g. Windows)
+    assert data["system"]["load_average_1m"] is None or isinstance(data["system"]["load_average_1m"], float)
+    assert data["system"]["load_average_5m"] is None or isinstance(data["system"]["load_average_5m"], float)
+    assert data["system"]["load_average_15m"] is None or isinstance(data["system"]["load_average_15m"], float)
+
+
+def test_get_database_status(client: TestClient):
+    """Test GET /api/v1/status/database endpoint."""
+    response = client.get("/api/v1/status/database")
+    assert response.status_code == 200
+    data = response.json()
+
+    expected_keys = ["connected", "message", "response_time_ms"]
+    for key in expected_keys:
+        assert key in data
+
+    assert data["connected"] is True
+    assert isinstance(data["message"], str)
+    assert isinstance(data["response_time_ms"], (int, float)) and data["response_time_ms"] >= 0
+
+# Test for database unavailable (Optional - skipping for now as mocking DB connection is complex)
+# def test_get_simple_status_db_unavailable(client: TestClient):
+#     # This test would require mocking the database connection to simulate unavailability
+#     # For now, we assume the happy path where the database is available
+#     pass

--- a/backend/app/tests/conftest.py
+++ b/backend/app/tests/conftest.py
@@ -1,0 +1,98 @@
+# backend/app/tests/conftest.py
+import pytest
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
+from typing import Callable # For type hinting factories
+import uuid # For potential default UUIDs if needed
+
+from app.main import app
+from app.db.database import Base, get_db
+# Import models that factories will create
+from app.db.models import User, Folder as FolderModel, Feed as FeedModel 
+from sqlalchemy.orm import Session
+
+
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+@pytest.fixture(scope="session")
+def db_engine():
+    Base.metadata.create_all(bind=engine)
+    yield engine
+
+
+@pytest.fixture(scope="function")
+def db_session(db_engine):
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    session = TestingSessionLocal(bind=connection)
+
+    yield session
+
+    session.close()
+    transaction.rollback()
+    connection.close()
+
+
+@pytest.fixture(scope="function")
+def client(db_session):
+    def override_get_db():
+        try:
+            yield db_session
+        finally:
+            db_session.close()
+
+    app.dependency_overrides[get_db] = override_get_db
+    yield TestClient(app)
+    del app.dependency_overrides[get_db]
+
+
+@pytest.fixture
+def folder_factory(db_session: Session) -> Callable[..., FolderModel]:
+    """Fixture to create Folder models directly in the database."""
+    def _create_folder(name: str = "Test Folder") -> FolderModel:
+        folder = FolderModel(name=name)
+        db_session.add(folder)
+        db_session.commit()
+        db_session.refresh(folder)
+        return folder
+    return _create_folder
+
+
+@pytest.fixture
+def feed_factory(db_session: Session) -> Callable[..., FeedModel]:
+    """Fixture to create Feed models directly in the database."""
+    def _create_feed(
+        feed_url: str = f"http://testfeed.com/{uuid.uuid4()}.rss", # Ensure unique URL by default
+        title: str = "Test Feed",
+        site_url: str = None, # Optional: use feed_url's domain if None
+        folder_id: uuid.UUID = None
+    ) -> FeedModel:
+        if site_url is None:
+            # Basic site_url derivation from feed_url
+            try:
+                site_url = "/".join(feed_url.split("/")[:3])
+            except Exception:
+                site_url = "http://defaultsite.com"
+
+
+        feed = FeedModel(
+            title=title,
+            feed_url=feed_url,
+            site_url=site_url,
+            folder_id=folder_id
+        )
+        db_session.add(feed)
+        db_session.commit()
+        db_session.refresh(feed)
+        return feed
+    return _create_feed

--- a/backend/app/tests/db/test_article_model.py
+++ b/backend/app/tests/db/test_article_model.py
@@ -1,0 +1,300 @@
+# backend/app/tests/db/test_article_model.py
+import pytest
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+from datetime import datetime, timezone
+
+from app.db.models import Article as ArticleModel
+from app.db.models import Feed as FeedModel # Needed for relationship / feed_factory
+
+
+# create_dummy_feed helper is removed, will use feed_factory fixture
+
+class TestArticleModel:
+
+    def test_create_article_success(self, db_session: Session, feed_factory):
+        feed = feed_factory() # Use feed_factory
+        
+        article_data = {
+            "feed_id": feed.id,
+            "title": "Test Article Title",
+            "link": "http://example.com/article1",
+            "published_at": datetime.now(timezone.utc),
+            "guid": "testguid1",
+            "description": "A short description.",
+            "image_url": "http://example.com/image.png"
+        }
+        
+        article = ArticleModel(**article_data)
+        db_session.add(article)
+        db_session.commit()
+        db_session.refresh(article)
+
+        assert article.id is not None
+        assert article.title == article_data["title"]
+        assert article.feed_id == feed.id
+        assert article.is_read is False # Default value
+        assert article.guid == "testguid1"
+
+    def test_article_relationship_with_feed(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedforrelation.com/rss") # Use feed_factory
+        
+        article = ArticleModel(
+            feed_id=feed.id,
+            title="Article for Feed Relation Test",
+            link="http://example.com/relation_test",
+            published_at=datetime.now(timezone.utc),
+            guid="guid_relation_test"
+        )
+        db_session.add(article)
+        db_session.commit()
+        db_session.refresh(article)
+        db_session.refresh(feed) # Refresh feed to see the relationship populated
+
+        assert article.feed is not None
+        assert article.feed.id == feed.id
+        assert article.feed.title == "Dummy Feed"
+        assert article in feed.articles
+
+    def test_article_default_is_read(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedfordefault.com/rss") # Use feed_factory
+        article = ArticleModel(
+            feed_id=feed.id,
+            title="Default Read Test",
+            link="http://example.com/default_read",
+            published_at=datetime.now(timezone.utc),
+            guid="guid_default_read"
+        )
+        db_session.add(article)
+        db_session.commit()
+        db_session.refresh(article)
+        
+        assert article.is_read is False
+
+    def test_article_guid_uniqueness_within_feed(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedforguid.com/rss") # Use feed_factory
+        common_guid = "unique_guid_123"
+
+        article1 = ArticleModel(
+            feed_id=feed.id,
+            title="Article 1 with GUID",
+            link="http://example.com/article_guid1",
+            published_at=datetime.now(timezone.utc),
+            guid=common_guid
+        )
+        db_session.add(article1)
+        db_session.commit()
+
+        article2_data = {
+            "feed_id": feed.id,
+            "title": "Article 2 with same GUID",
+            "link": "http://example.com/article_guid2",
+            "published_at": datetime.now(timezone.utc),
+            "guid": common_guid # Same GUID
+        }
+        article2 = ArticleModel(**article2_data)
+        db_session.add(article2)
+        
+        # The unique constraint is (feed_id, guid)
+        with pytest.raises(IntegrityError):
+            db_session.commit()
+        db_session.rollback()
+
+    def test_article_guid_can_be_same_for_different_feeds(self, db_session: Session, feed_factory):
+        feed1 = feed_factory(feed_url="http://feed1_for_guid.com/rss") # Use feed_factory
+        feed2 = feed_factory(feed_url="http://feed2_for_guid.com/rss") # Use feed_factory
+        common_guid = "shared_guid_across_feeds"
+
+        article1 = ArticleModel(
+            feed_id=feed1.id,
+            title="Article Feed1",
+            link="http://example.com/f1_article",
+            published_at=datetime.now(timezone.utc),
+            guid=common_guid
+        )
+        db_session.add(article1)
+        db_session.commit()
+
+        article2 = ArticleModel(
+            feed_id=feed2.id,
+            title="Article Feed2",
+            link="http://example.com/f2_article",
+            published_at=datetime.now(timezone.utc),
+            guid=common_guid # Same GUID, but different feed
+        )
+        db_session.add(article2)
+        
+        # This should commit successfully
+        db_session.commit()
+        db_session.refresh(article1)
+        db_session.refresh(article2)
+
+        assert article1.guid == common_guid
+        assert article2.guid == common_guid
+        assert article1.feed_id != article2.feed_id
+        
+    def test_article_missing_required_fields_sqlalchemy(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedformissing.com/rss") # Use feed_factory
+        # Test missing title (nullable=False)
+        with pytest.raises(IntegrityError):
+            article_no_title = ArticleModel(
+                feed_id=feed.id, 
+                link="http://example.com/no_title", 
+                published_at=datetime.now(timezone.utc),
+                guid="guid_no_title"
+            )
+            db_session.add(article_no_title)
+            db_session.commit()
+        db_session.rollback()
+
+        # Test missing link (nullable=False)
+        with pytest.raises(IntegrityError):
+            article_no_link = ArticleModel(
+                feed_id=feed.id, 
+                title="No Link Article", 
+                published_at=datetime.now(timezone.utc),
+                guid="guid_no_link"
+            )
+            db_session.add(article_no_link)
+            db_session.commit()
+        db_session.rollback()
+        
+        # Test missing guid (nullable=False)
+        with pytest.raises(IntegrityError):
+            article_no_guid = ArticleModel(
+                feed_id=feed.id, 
+                title="No GUID Article", 
+                link="http://example.com/no_guid",
+                published_at=datetime.now(timezone.utc)
+            )
+            db_session.add(article_no_guid)
+            db_session.commit()
+        db_session.rollback()
+
+        # Test missing published_at (nullable=True in model)
+        article_no_published_at = ArticleModel(
+            feed_id=feed.id,
+            title="No Published At Article",
+            link="http://example.com/no_published_at",
+            guid="guid_no_published_at"
+        )
+        db_session.add(article_no_published_at)
+        db_session.commit() # Should succeed as published_at is nullable in model
+        assert article_no_published_at.published_at is None
+        db_session.delete(article_no_published_at) # cleanup
+        db_session.commit()
+
+    def test_article_string_field_lengths(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedforlengths.com") # Use feed_factory
+        # title: String(255)
+        # link: String(2048)
+        # guid: String(2048)
+        # description: Text (effectively unlimited for this test)
+        # image_url: String(2048)
+
+        long_title = "t" * 256
+        long_link = "l" * 2049
+        long_guid = "g" * 2049
+        long_image_url = "i" * 2049
+
+        # SQLAlchemy itself doesn't always enforce length constraints before commit
+        # if the DB backend truncates or errors. The error type can vary.
+        # For SQLite, it often truncates or doesn't error.
+        # PostgreSQL would raise DataError.
+        # We are testing against SQLite in memory, which might not strictly enforce.
+        # The real enforcement is at the DB schema level.
+        # However, it's good practice to have this test.
+
+        # Test title length (expect no error from SQLAlchemy on SQLite, but good to have)
+        article_long_title = ArticleModel(
+            feed_id=feed.id, title="t" * 255, link="http://ok.com", guid="guid_len1", published_at=datetime.now(timezone.utc)
+        )
+        db_session.add(article_long_title)
+        db_session.commit() # Should be fine
+        db_session.delete(article_long_title)
+        db_session.commit()
+
+        # If we were on PostgreSQL and a value too long was inserted,
+        # an IntegrityError (or specific DataError) would be raised upon commit.
+        # For now, this test mostly serves as documentation of expected lengths.
+        # A more robust test would involve a DB that strictly enforces lengths.
+        pass # Skipping explicit checks for >max length errors for SQLite's behavior.
+             # The schema definition is the source of truth for max lengths.
+             # API level tests with schemas would catch this if schemas include length validation.
+             # Pydantic schemas for create/update should ideally have these length constraints.
+             # Let's assume schemas/API layer handle this.
+             # The main purpose here is to check if the model can hold max length.
+        
+        article_max_lengths = ArticleModel(
+            feed_id=feed.id,
+            title="t" * 255,
+            link="l" * 2048,
+            published_at=datetime.now(timezone.utc),
+            guid="g" * 2048,
+            description="Some description",
+            image_url="i" * 2048
+        )
+        db_session.add(article_max_lengths)
+        db_session.commit()
+        db_session.refresh(article_max_lengths)
+        assert len(article_max_lengths.title) == 255
+        assert len(article_max_lengths.link) == 2048
+        assert len(article_max_lengths.guid) == 2048
+        assert len(article_max_lengths.image_url) == 2048
+
+        db_session.delete(article_max_lengths)
+        db_session.commit()
+
+    # Test for created_at and updated_at defaults/updates is omitted as they are handled by db.utils.TimestampMixin
+    # and are implicitly tested when an object is created or updated.
+    # If there were specific logic beyond the mixin, it would be tested here.
+    
+    # Test for content field (CLOB/TEXT) - usually just check it can store large text
+    def test_article_content_field(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedforcontent.com") # Use feed_factory
+        large_content = "This is a very large content string. " * 1000 # Approx 40k chars
+
+        article = ArticleModel(
+            feed_id=feed.id,
+            title="Content Test",
+            link="http://example.com/content_test",
+            published_at=datetime.now(timezone.utc),
+            guid="guid_content_test",
+            content=large_content
+        )
+        db_session.add(article)
+        db_session.commit()
+        db_session.refresh(article)
+
+        assert article.content == large_content
+        db_session.delete(article)
+        db_session.commit()
+
+    # Test boolean is_read can be updated
+    def test_update_article_is_read(self, db_session: Session, feed_factory):
+        feed = feed_factory(feed_url="http://feedforisreadupdate.com") # Use feed_factory
+        article = ArticleModel(
+            feed_id=feed.id,
+            title="Update Read Status",
+            link="http://example.com/update_read",
+            published_at=datetime.now(timezone.utc),
+            guid="guid_update_read"
+        )
+        db_session.add(article)
+        db_session.commit()
+        db_session.refresh(article)
+
+        assert article.is_read is False # Default
+
+        article.is_read = True
+        db_session.commit()
+        db_session.refresh(article)
+        assert article.is_read is True
+
+        article.is_read = False
+        db_session.commit()
+        db_session.refresh(article)
+        assert article.is_read is False
+        
+        db_session.delete(article)
+        db_session.commit()

--- a/backend/app/tests/schemas/test_article_schema.py
+++ b/backend/app/tests/schemas/test_article_schema.py
@@ -1,0 +1,221 @@
+# backend/app/tests/schemas/test_article_schema.py
+import pytest
+from pydantic import ValidationError
+from datetime import datetime, timezone
+import uuid
+
+from app.schemas.article import ArticleBase, ArticleCreate, Article as ArticleSchema
+from app.db.models import Article as ArticleModel # For from_orm test
+
+# Get the current time in UTC, ensuring it's offset-aware for Pydantic v2
+NOW_UTC = datetime.now(timezone.utc)
+
+VALID_ARTICLE_DATA = {
+    "title": "Valid Article Title",
+    "link": "http://example.com/valid_article",
+    "published_at": NOW_UTC, # Use offset-aware datetime
+    "guid": "valid_guid_123",
+    "description": "This is a valid description.",
+    "image_url": "http://example.com/valid_image.png"
+}
+
+class TestArticleSchemas:
+
+    # Test ArticleBase (implicitly tested via ArticleCreate, but can add specific if needed)
+    def test_article_base_valid(self):
+        data = {
+            "title": "Base Title",
+            "link": "http://example.com/base",
+            "published_at": NOW_UTC,
+            "guid": "base_guid",
+            "description": "Base description",
+            "image_url": "http://example.com/base.png"
+        }
+        article = ArticleBase(**data)
+        assert article.title == data["title"]
+        assert article.link == data["link"]
+        assert article.published_at == data["published_at"]
+        # Ensure published_at is offset-aware after parsing
+        assert article.published_at.tzinfo is not None 
+        assert article.guid == data["guid"]
+        assert article.description == data["description"]
+        assert article.image_url == data["image_url"]
+
+    def test_article_base_optional_fields(self):
+        data = {
+            "title": "Base Title Optional",
+            "link": "http://example.com/base_optional",
+            "published_at": NOW_UTC, # This is actually optional in ArticleBase, but usually required in Create
+            "guid": "base_guid_optional",
+        }
+        # published_at is optional in ArticleBase, description, image_url too.
+        article = ArticleBase(**data)
+        assert article.title == data["title"]
+        assert article.published_at == data["published_at"]
+        assert article.description is None
+        assert article.image_url is None
+    
+    # Test ArticleCreate
+    def test_article_create_valid(self):
+        article_create = ArticleCreate(**VALID_ARTICLE_DATA)
+        assert article_create.title == VALID_ARTICLE_DATA["title"]
+        assert article_create.link == VALID_ARTICLE_DATA["link"]
+        assert article_create.published_at == VALID_ARTICLE_DATA["published_at"]
+        assert article_create.published_at.tzinfo is not None
+        assert article_create.guid == VALID_ARTICLE_DATA["guid"]
+        assert article_create.description == VALID_ARTICLE_DATA["description"]
+        assert article_create.image_url == VALID_ARTICLE_DATA["image_url"]
+
+    def test_article_create_missing_required_fields(self):
+        required_fields = ["title", "link", "guid"] # published_at is optional in ArticleCreate in schema
+                                                    # but practically always provided by parser
+        
+        # Test missing published_at (it's optional in ArticleCreate as per schema)
+        data_no_published_at = VALID_ARTICLE_DATA.copy()
+        del data_no_published_at["published_at"]
+        ac = ArticleCreate(**data_no_published_at) # Should pass
+        assert ac.published_at is None
+
+
+        for field in required_fields:
+            data = VALID_ARTICLE_DATA.copy()
+            del data[field]
+            with pytest.raises(ValidationError) as exc_info:
+                ArticleCreate(**data)
+            assert field in str(exc_info.value) # Check that the missing field is mentioned in the error
+
+    def test_article_create_invalid_types(self):
+        # Invalid link (not a URL)
+        with pytest.raises(ValidationError) as exc_info:
+            ArticleCreate(**{**VALID_ARTICLE_DATA, "link": "not-a-url"})
+        assert "link" in str(exc_info.value).lower() # field name in error
+        assert "url" in str(exc_info.value).lower() # type error reason
+
+        # Invalid published_at (not a datetime string)
+        with pytest.raises(ValidationError) as exc_info:
+            ArticleCreate(**{**VALID_ARTICLE_DATA, "published_at": "not-a-date"})
+        assert "published_at" in str(exc_info.value).lower()
+        assert "datetime_from_datetimestring" in str(exc_info.value).lower() # Pydantic v1
+        # For Pydantic v2, error type might be 'datetime_parsing'
+
+        # Invalid image_url (not a URL)
+        with pytest.raises(ValidationError) as exc_info:
+            ArticleCreate(**{**VALID_ARTICLE_DATA, "image_url": "not-a-url-either"})
+        assert "image_url" in str(exc_info.value).lower()
+        assert "url" in str(exc_info.value).lower()
+
+
+    def test_article_create_optional_fields_not_present(self):
+        # image_url and description are optional
+        data = {
+            "title": "Minimal Article",
+            "link": "http://example.com/minimal",
+            "published_at": NOW_UTC,
+            "guid": "minimal_guid"
+        }
+        article_create = ArticleCreate(**data)
+        assert article_create.title == data["title"]
+        assert article_create.description is None
+        assert article_create.image_url is None
+
+    def test_article_create_empty_string_for_optional_url(self):
+        # Pydantic by default treats empty string "" as invalid for HttpUrl.
+        # If "" should be coerced to None, a pre-validator is needed.
+        # Assuming default behavior: "" is not a valid URL.
+        with pytest.raises(ValidationError) as exc_info:
+            ArticleCreate(**{**VALID_ARTICLE_DATA, "image_url": ""})
+        assert "image_url" in str(exc_info.value).lower()
+
+    # Test Article (response schema)
+    def test_article_response_schema_from_orm(self):
+        # Create a mock ORM object (needs all fields expected by Article schema)
+        mock_orm_article = ArticleModel(
+            id=uuid.uuid4(),
+            feed_id=uuid.uuid4(),
+            title="ORM Article Title",
+            link="http://example.com/orm_article",
+            published_at=NOW_UTC,
+            guid="orm_guid_123",
+            description="ORM description.",
+            image_url="http://example.com/orm_image.png",
+            is_read=False,
+            created_at=NOW_UTC,
+            updated_at=NOW_UTC,
+            content="Full article content here" # content is in ArticleModel
+        )
+
+        article_schema = ArticleSchema.model_validate(mock_orm_article) # Pydantic v2
+        # article_schema = ArticleSchema.from_orm(mock_orm_article) # Pydantic v1
+
+        assert article_schema.id == mock_orm_article.id
+        assert article_schema.feed_id == mock_orm_article.feed_id
+        assert article_schema.title == mock_orm_article.title
+        assert article_schema.link == mock_orm_article.link
+        assert article_schema.published_at == mock_orm_article.published_at
+        assert article_schema.published_at.tzinfo is not None
+        assert article_schema.guid == mock_orm_article.guid
+        assert article_schema.description == mock_orm_article.description
+        assert article_schema.image_url == mock_orm_article.image_url
+        assert article_schema.is_read == mock_orm_article.is_read
+        assert article_schema.created_at == mock_orm_article.created_at
+        assert article_schema.updated_at == mock_orm_article.updated_at
+        # content is not part of the Article response schema by default, check schema definition
+        # As per current schema: `content: Optional[str] = None`
+        assert article_schema.content == mock_orm_article.content
+
+
+    def test_article_response_schema_optional_fields_from_orm(self):
+        mock_orm_article_minimal = ArticleModel(
+            id=uuid.uuid4(),
+            feed_id=uuid.uuid4(),
+            title="ORM Minimal Article",
+            link="http://example.com/orm_minimal",
+            guid="orm_guid_minimal",
+            is_read=True,
+            created_at=NOW_UTC,
+            updated_at=NOW_UTC
+            # published_at, description, image_url, content are None/default
+        )
+        
+        article_schema = ArticleSchema.model_validate(mock_orm_article_minimal) # Pydantic v2
+        # article_schema = ArticleSchema.from_orm(mock_orm_article_minimal) # Pydantic v1
+
+        assert article_schema.id == mock_orm_article_minimal.id
+        assert article_schema.published_at is None # Default in model is None
+        assert article_schema.description is None
+        assert article_schema.image_url is None
+        assert article_schema.content is None
+        assert article_schema.is_read is True
+
+    # Test datetime parsing string with Z (Zulu time / UTC)
+    def test_article_create_datetime_with_zulu(self):
+        data_zulu_time = {
+            **VALID_ARTICLE_DATA,
+            "published_at": "2023-01-01T12:00:00Z" 
+        }
+        article_create = ArticleCreate(**data_zulu_time)
+        expected_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+        assert article_create.published_at == expected_dt
+        assert article_create.published_at.tzinfo == timezone.utc
+
+    # Test datetime parsing string with timezone offset
+    def test_article_create_datetime_with_offset(self):
+        data_offset_time = {
+            **VALID_ARTICLE_DATA,
+            "published_at": "2023-01-01T12:00:00+02:00"
+        }
+        article_create = ArticleCreate(**data_offset_time)
+        # Pydantic should convert this to UTC if that's the standard, or preserve offset
+        # By default, Pydantic v2 parses into an offset-aware datetime
+        assert article_create.published_at.year == 2023
+        assert article_create.published_at.hour == 12 # hour in original timezone
+        assert article_create.published_at.tzinfo is not None
+        
+        # To compare apples to apples, convert to UTC
+        assert article_create.published_at.astimezone(timezone.utc) == datetime(2023, 1, 1, 10, 0, 0, tzinfo=timezone.utc)
+
+    # Test length constraints for ArticleCreate if defined in schema
+    # (Assuming no explicit length constraints in Pydantic schemas for now, as models handle DB limits)
+    # If `Field(max_length=...)` was used in schemas, those tests would go here.
+    # def test_article_create_field_max_lengths(self):
+    #     pass


### PR DESCRIPTION
I've implemented a test suite for the FastAPI backend, covering:

- Status endpoints (/api/v1/status/*)
- Folder management endpoints (/api/v1/folders/*)
- Feed management endpoints (/api/v1/feeds/*)
- Article model and schema unit tests

Key features of the test suite:
- It utilizes pytest and FastAPI's TestClient.
- It uses an in-memory SQLite database for test isolation and speed.
- It mocks external services (e.g., feed parsing) to ensure reliable tests.
- It includes fixtures for common setup (e.g., test client, DB session, model factories).
- It covers various scenarios including success cases, error handling (e.g., duplicate entries, invalid data, not found), and edge cases.

The test suite significantly improves backend code quality and provides a safety net for future development and refactoring.